### PR TITLE
fix(sync): use parentId for page hierarchy in create/update

### DIFF
--- a/src/lib/page-client.ts
+++ b/src/lib/page-client.ts
@@ -52,7 +52,7 @@ export class PageClient {
 		document: AdfDocumentHelper,
 	): Promise<Required<CreatePage200Response>> {
 		const pageData = {
-			pageId: this.args.pageId,
+			parentId: this.args.pageId,
 			spaceId: this.args.spaceId,
 			status: "current" as const,
 			title: document.title,
@@ -79,6 +79,7 @@ export class PageClient {
 
 		const updateData = {
 			id: pageInfo.id,
+			parentId: this.args.pageId,
 			status: "current" as const,
 			title: document.title,
 			body: {


### PR DESCRIPTION
## Summary
Fixes #4 by wiring the sync parent page option to the correct Confluence v2 request field.

## Changes
- createPage() now sends parentId (instead of invalid pageId)
- updatePage() now also sends parentId, enabling re-parenting during sync

## Validation
- npm test
