### PR TITLE
fix(cli): use continue instead of return for optional options

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -150,7 +150,7 @@ const main = async (command: Command, options: Options) => {
 	assert(cmd, `Unknown command: "${command}"`);
 
 	for (const [key, opt] of Object.entries(expectedOptions)) {
-		if (opt.optional) return;
+		if (opt.optional) continue;
 
 		assert(
 			key in options,


### PR DESCRIPTION
Fixes #6

In the validation loop in `main()`, `return` was used instead of `continue` for optional options. This caused the function to exit early without ever calling `cmd()`, so sync (and any command with optional options) silently did nothing.