### PR TITLE
feat(document): support frontmatter for page identity

### DIFF
--- a/src/lib/document.test.ts
+++ b/src/lib/document.test.ts
@@ -1,7 +1,9 @@
 import assert from "node:assert";
+import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { AdfDocumentHelper } from "./document";
+import { AdfDocumentHelper, parseFrontmatter } from "./document";
 
 test("AdfDocumentHelper.listImages returns an array (README.md)", () => {
 	const adfDoc = AdfDocumentHelper.fromMarkdownFile("README.md");
@@ -35,6 +37,59 @@ test("AdfDocumentHelper handles special characters in file name", () => {
 	const adfDoc = AdfDocumentHelper.fromMarkdownFile(filePath);
 	assert.strictEqual(adfDoc.title, "spécial-chär");
 	require("node:fs").unlinkSync(filePath);
+});
+
+test("parseFrontmatter extracts confluence_page_title", () => {
+	const { frontmatter, body } = parseFrontmatter(
+		"---\nconfluence_page_title: My Page\n---\n# Hello\n",
+	);
+	assert.strictEqual(frontmatter.confluence_page_title, "My Page");
+	assert.strictEqual(body, "# Hello\n");
+});
+
+test("parseFrontmatter extracts confluence_page_id", () => {
+	const { frontmatter } = parseFrontmatter(
+		"---\nconfluence_page_id: 2223177735\n---\nContent\n",
+	);
+	assert.strictEqual(frontmatter.confluence_page_id, "2223177735");
+});
+
+test("parseFrontmatter returns empty frontmatter for plain markdown", () => {
+	const { frontmatter, body } = parseFrontmatter("# Just markdown\n");
+	assert.deepStrictEqual(frontmatter, {});
+	assert.strictEqual(body, "# Just markdown\n");
+});
+
+test("fromMarkdownFile uses confluence_page_title from frontmatter", () => {
+	const tmp = path.join(os.tmpdir(), "fm-title-test.md");
+	fs.writeFileSync(tmp, "---\nconfluence_page_title: FM Title\n---\n# Body\n");
+	const doc = AdfDocumentHelper.fromMarkdownFile(tmp);
+	assert.strictEqual(doc.title, "FM Title");
+	fs.unlinkSync(tmp);
+});
+
+test("fromMarkdownFile stores confluence_page_id", () => {
+	const tmp = path.join(os.tmpdir(), "fm-id-test.md");
+	fs.writeFileSync(tmp, "---\nconfluence_page_id: 12345\n---\n# Body\n");
+	const doc = AdfDocumentHelper.fromMarkdownFile(tmp);
+	assert.strictEqual(doc.confluencePageId, "12345");
+	fs.unlinkSync(tmp);
+});
+
+test("frontmatter title takes precedence over overrideTitle", () => {
+	const tmp = path.join(os.tmpdir(), "fm-precedence-test.md");
+	fs.writeFileSync(
+		tmp,
+		"---\nconfluence_page_title: Frontmatter Wins\n---\n# Body\n",
+	);
+	const doc = AdfDocumentHelper.fromMarkdownFile(tmp, "CLI Title");
+	assert.strictEqual(doc.title, "Frontmatter Wins");
+	fs.unlinkSync(tmp);
+});
+
+test("overrideTitle is used when no frontmatter title", () => {
+	const doc = AdfDocumentHelper.fromMarkdownFile("README.md", "CLI Title");
+	assert.strictEqual(doc.title, "CLI Title");
 });
 
 test("AdfDocumentHelper throws on non-existent file", (_t) => {

--- a/src/lib/document.ts
+++ b/src/lib/document.ts
@@ -14,15 +14,50 @@ interface AdfMark {
 	attrs?: Record<string, unknown>;
 }
 
+interface Frontmatter {
+	confluence_page_id?: string;
+	confluence_page_title?: string;
+}
+
+export function parseFrontmatter(content: string): {
+	frontmatter: Frontmatter;
+	body: string;
+} {
+	const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n/);
+	if (!match) return { frontmatter: {}, body: content };
+
+	const frontmatter: Frontmatter = {};
+	for (const line of match[1].split(/\r?\n/)) {
+		const sep = line.indexOf(":");
+		if (sep === -1) continue;
+		const key = line.slice(0, sep).trim();
+		const value = line.slice(sep + 1).trim();
+		if (key === "confluence_page_id") frontmatter.confluence_page_id = value;
+		if (key === "confluence_page_title")
+			frontmatter.confluence_page_title = value;
+	}
+
+	return { frontmatter, body: content.slice(match[0].length) };
+}
+
 export class AdfDocumentHelper {
 	readonly title: string;
 	readonly content: AdfNode;
 	readonly sourceFile?: string;
+	readonly confluencePageId?: string;
+	readonly confluencePageTitle?: string;
 
-	constructor(title: string, adfContent: AdfNode, sourceFile?: string) {
+	constructor(
+		title: string,
+		adfContent: AdfNode,
+		sourceFile?: string,
+		frontmatter?: Frontmatter,
+	) {
 		this.title = title;
 		this.content = adfContent;
 		this.sourceFile = sourceFile;
+		this.confluencePageId = frontmatter?.confluence_page_id;
+		this.confluencePageTitle = frontmatter?.confluence_page_title;
 	}
 
 	static fromMarkdownFile(
@@ -31,10 +66,13 @@ export class AdfDocumentHelper {
 	): AdfDocumentHelper {
 		const resolvedPath = resolve(filePath);
 		const markdownContent = readFileSync(resolvedPath, "utf-8");
-		const adfContent = markdownToAdf(markdownContent);
+		const { frontmatter, body } = parseFrontmatter(markdownContent);
+		const adfContent = markdownToAdf(body);
 		const title =
-			overrideTitle || AdfDocumentHelper.getPageTitleFromPath(filePath);
-		return new AdfDocumentHelper(title, adfContent, filePath);
+			frontmatter.confluence_page_title ||
+			overrideTitle ||
+			AdfDocumentHelper.getPageTitleFromPath(filePath);
+		return new AdfDocumentHelper(title, adfContent, filePath, frontmatter);
 	}
 
 	private static getPageTitleFromPath(filePath: string): string {

--- a/src/lib/page-client.ts
+++ b/src/lib/page-client.ts
@@ -120,6 +120,10 @@ export class PageClient {
 	async findOrCreatePage(
 		document: AdfDocumentHelper,
 	): Promise<Required<CreatePage200Response>> {
+		if (document.confluencePageId) {
+			return this.getPage(document.confluencePageId);
+		}
+
 		const current = await this.findPageByTitle(document.title);
 
 		if (!current) {


### PR DESCRIPTION
Fixes #7

Adds support for YAML frontmatter in markdown files to pin Confluence page identity:

```yaml
---
confluence_page_id: 2223177735
confluence_page_title: My Page Title
---
```

Resolution order:
1. `confluence_page_id` in frontmatter → update page directly
2. `confluence_page_title` in frontmatter → match by title
3. `--title` CLI flag → use as title
4. Filename-derived title (existing behavior)