### PR TITLE
feat: add dry-run command

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -71,6 +71,23 @@ const commands = {
 			return client.sync();
 		},
 	},
+	"dry-run": {
+		description:
+			"Check if page needs syncing (exits 0 if stale/missing, 1 if up-to-date)",
+		options: { ...allOptions, file, title: options.title },
+		cmd: async (args: Options) => {
+			const document = AdfDocumentHelper.fromMarkdownFile(
+				args.file,
+				args.title,
+			);
+			const client = new PageClient(args, document);
+			const result = await client.checkFreshness();
+			if (result.status === "up-to-date") {
+				process.exitCode = 1;
+			}
+			return result;
+		},
+	},
 	list: {
 		description: "List pages in space",
 		options: allOptions,

--- a/src/lib/page-client.ts
+++ b/src/lib/page-client.ts
@@ -133,6 +133,41 @@ export class PageClient {
 		return this.getPage(current.id);
 	}
 
+	async checkFreshness(): Promise<{
+		status: "missing" | "stale" | "up-to-date";
+		title: string;
+		pageUpdated?: string;
+	}> {
+		if (!this.document) {
+			throw new Error("Document is required for dry-run command");
+		}
+
+		const { title } = this.document;
+		const page = await this.findPageByTitle(title);
+
+		if (!page) {
+			return { status: "missing", title };
+		}
+
+		const currentContent = this.document.getContentAsString();
+		const existingPage = await this.getPage(page.id);
+		const existingContent = existingPage.body?.atlas_doc_format?.value ?? "";
+
+		if (currentContent !== existingContent) {
+			return {
+				status: "stale",
+				title,
+				pageUpdated: existingPage.version?.createdAt,
+			};
+		}
+
+		return {
+			status: "up-to-date",
+			title,
+			pageUpdated: existingPage.version?.createdAt,
+		};
+	}
+
 	async sync(): Promise<CreatePage200Response> {
 		if (!this.document) {
 			throw new Error("Document is required for create command");


### PR DESCRIPTION
Adds a `dry-run` command that checks if a page needs syncing without actually publishing.

Compares local markdown content (as ADF) against the existing Confluence page content.

**Exit codes:**
- `0` — page is missing or stale (needs publish)
- `1` — page is up-to-date (skip)

**Usage:**
```bash
npx @kattebak/markdown-confluence-cli dry-run -f doc.md -l "Page Title" -u $USER -t $TOKEN -d $DOMAIN -i $SPACE_ID
```

This enables CI to selectively publish only docs that actually changed.