### PR TITLE
feat: support confluence_parent_id in frontmatter

### DIFF
--- a/src/lib/document.ts
+++ b/src/lib/document.ts
@@ -17,6 +17,7 @@ interface AdfMark {
 interface Frontmatter {
 	confluence_page_id?: string;
 	confluence_page_title?: string;
+	confluence_parent_id?: string;
 }
 
 export function parseFrontmatter(content: string): {
@@ -35,6 +36,8 @@ export function parseFrontmatter(content: string): {
 		if (key === "confluence_page_id") frontmatter.confluence_page_id = value;
 		if (key === "confluence_page_title")
 			frontmatter.confluence_page_title = value;
+		if (key === "confluence_parent_id")
+			frontmatter.confluence_parent_id = value;
 	}
 
 	return { frontmatter, body: content.slice(match[0].length) };
@@ -46,6 +49,7 @@ export class AdfDocumentHelper {
 	readonly sourceFile?: string;
 	readonly confluencePageId?: string;
 	readonly confluencePageTitle?: string;
+	readonly confluenceParentId?: string;
 
 	constructor(
 		title: string,
@@ -58,6 +62,7 @@ export class AdfDocumentHelper {
 		this.sourceFile = sourceFile;
 		this.confluencePageId = frontmatter?.confluence_page_id;
 		this.confluencePageTitle = frontmatter?.confluence_page_title;
+		this.confluenceParentId = frontmatter?.confluence_parent_id;
 	}
 
 	static fromMarkdownFile(

--- a/src/lib/page-client.ts
+++ b/src/lib/page-client.ts
@@ -48,11 +48,15 @@ export class PageClient {
 		return page ? (page as Required<PageBulk>) : null;
 	}
 
+	private get parentId(): string | undefined {
+		return this.document?.confluenceParentId ?? this.args.pageId;
+	}
+
 	async createPage(
 		document: AdfDocumentHelper,
 	): Promise<Required<CreatePage200Response>> {
 		const pageData = {
-			parentId: this.args.pageId,
+			parentId: this.parentId,
 			spaceId: this.args.spaceId,
 			status: "current" as const,
 			title: document.title,
@@ -79,7 +83,7 @@ export class PageClient {
 
 		const updateData = {
 			id: pageInfo.id,
-			parentId: this.args.pageId,
+			parentId: this.parentId,
 			status: "current" as const,
 			title: document.title,
 			body: {


### PR DESCRIPTION
Adds `confluence_parent_id` frontmatter field. Overrides `-p` CLI arg when set.

```yaml
---
confluence_parent_id: 2258894874
confluence_page_title: My Document
---
```